### PR TITLE
Update referencers: TGLF Experimental Validation Publications

### DIFF
--- a/html/src/references.bib
+++ b/html/src/references.bib
@@ -1359,3 +1359,61 @@
                   Knoxville, TN, May 16-19},
 		  year = 2005
 }
+
+@Article{	  white:2008,
+  title =	 {{Measurements of core electron temperature and
+                  density fluctuations in DIII-D and comparison to
+                  nonlinear gyrokinetic simulations)}},
+  author =	 {A.E. White and L. Schmitz and G.R. McKee and C. Holland and W.A. Peebles
+                 and T.A. Carter and M.W. Shafer and M.E. Austin and K.H. Burrell and J. Candy
+		 and others},
+  journal =	 pop,
+  number =	 5,
+  pages =	 056116,
+  volume =	 15,
+  year =	 2008
+}
+
+@Article{	  grierson_ITER_baseline:2018,
+  title =	 {{Multi-scale transport in the DIII-D ITER baseline scenario with direct electron heating and projection to ITER}},
+  author =	 {B. A. Grierson, G. M. Staebler,  W. M. Solomon, G. R. McKee, C. Holland, M. Austin, A. Marinoni, L. Schmitz, R. I. Pinsker, and DIII-D Team},
+  journal =	 pop,
+  number =	 2,
+  pages =	 022509,
+  volume =	 25,
+  year =	 2018
+}
+
+@Article{	  thome:2021,
+  title =	 {{Response of thermal and fast-ion transport to beam ion population, rotation and Te/Ti in the DIII-D steady state hybrid scenario}},
+  author =	 {K.E. Thome, X.D. Du, B.A. Grierson, G.J. Kramer, C.C. Petty, C. Holland, M. Knolker , G.R. McKee, J. McClenaghan, D.C. Pace, T.L. Rhodes, S.P. Smith, C. Sung, F. Turco, M.A. Van Zeeland, L. Zeng and Y.B. Zhu}
+  journal =	 nf,
+  pages =	 036036,
+  volume =	 61,
+  year =	 2021
+}
+
+@Article{	 kaye:2019,
+  title =	 {{NSTX/NSTX-U theory, modeling and analysis results}},
+  author =	 {S.M. Kaye and others}
+  journal =	 nf,
+  pages =	 112007,
+  volume =	 59,
+  year =	 2019
+}
+
+
+@Article {Angioni:2022,
+	doi = {10.1088/1741-4326/ac592b},
+	url = {https://doi.org/10.1088/1741-4326/ac592b},
+	year = 2022,
+	month = {apr},
+	publisher = {{IOP} Publishing},
+	volume = {62},
+	number = {6},
+	pages = {066015},
+	author = {C. Angioni and T. Gamot and G. Tardini and E. Fable and T. Luda and N. Bonanomi and C.K. Kiefer and G.M. Staebler and  the ASDEX Upgrade Team and  the EUROfusion MST1 Team},
+	title = {{Confinement properties of L-mode plasmas in {ASDEX} Upgrade and full-radius predictions of the {TGLF} transport model}},
+	journal = {Nuclear Fusion}
+}
+

--- a/html/src/zreferences.rst
+++ b/html/src/zreferences.rst
@@ -15,3 +15,15 @@ References
 
 	    
 .. bibliography:: references.bib
+
+
+.. csv-table:: **References: TGLF validation against experimental data**
+   :header: "Device",  "Required citation"
+   :widths: 20,20
+
+    DIII-D, ":cite:`grierson_ITER_baseline:2018,thome:2021`"
+    NSTX,  ":cite:`kaye:2019`"
+    ASDEX,  ":cite:`Angioni:2022`"
+    
+
+	    


### PR DESCRIPTION
It would be very useful for a new people at GA or new TGLF users to see how this model has been used and validated on experimental data so far.  It would be great to have a list of references in one place, ideally with brief conclusions. I see the list of references on the [TGLF DIII-D wiki page ](https://fusion.gat.com/theory/Tglfoverview), but a lot of work been done since 2014.

I started to make a list and would appreciate if people can add other references they know about. 


![Screen Shot 2022-08-29 at 2 03 54 PM](https://user-images.githubusercontent.com/80053907/187268286-0bbc7411-3e8e-4656-a6e6-9e9d1c3ed9cf.png)
